### PR TITLE
Add github workflow to sync Suave library

### DIFF
--- a/.github/workflows/suave-lib-sync.yml
+++ b/.github/workflows/suave-lib-sync.yml
@@ -36,3 +36,9 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
+        with:
+          title: "Update Suave library"
+          delete-branch: true
+          labels: |
+            suave-lib-update
+            automated pr

--- a/.github/workflows/suave-lib-sync.yml
+++ b/.github/workflows/suave-lib-sync.yml
@@ -1,0 +1,38 @@
+name: SuaveLib sync
+
+on: [repository_dispatch, workflow_dispatch]
+
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Checkout tools repo
+        uses: actions/checkout@v4
+        with:
+          repository: flashbots/suave-geth
+          path: suave-geth
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Mirror
+        run: |
+          cp suave-geth/suave/sol/libraries/Suave.sol ./src/suavelib/Suave.sol
+          cp suave-geth/suave/sol/libraries/SuaveForge.sol ./src/suavelib/SuaveForge.sol
+          git add ./src/suavelib/Suave.sol
+          git add ./src/suavelib/SuaveForge.sol
+          rm -rf suave-geth
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/suave-lib-sync.yml
+++ b/.github/workflows/suave-lib-sync.yml
@@ -26,6 +26,13 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Get Commit ID
+        id: get_commit_id
+        run: |
+          cd suave-geth
+          commit_id=$(git rev-parse HEAD)
+          echo "commit_ref=https://github.com/flashbots/suave-geth/commit/$commit_id" >> $GITHUB_OUTPUT
+
       - name: Mirror
         run: |
           cp suave-geth/suave/sol/libraries/Suave.sol ./src/suavelib/Suave.sol
@@ -39,6 +46,10 @@ jobs:
         with:
           title: "Update Suave library"
           delete-branch: true
+          commit-message: Update Suave.sol library to ${{ steps.get_commit_id.outputs.commit_ref }}
+          branch: bot/suave-lib-update
           labels: |
             suave-lib-update
             automated pr
+          body: |
+            Update Suave.sol library to ${{ steps.get_commit_id.outputs.commit_ref }}


### PR DESCRIPTION
Partially addresses #4. This workflow pulls the Suave.sol libraries from `suave-geth` and mirrors the content for `Suave.sol` and `SuaveForge.sol`. For now, the workflow is triggered manually in the Github actions UI.