### PR TITLE
Fix kettle addr padding

### DIFF
--- a/src/Context.sol
+++ b/src/Context.sol
@@ -9,7 +9,13 @@ library Context {
     }
 
     function kettleAddress() internal returns (address) {
-        bytes memory addr = Suave.contextGet("kettleAddress");
-        return abi.decode(addr, (address));
+        bytes memory _bytes = Suave.contextGet("kettleAddress");
+
+        address addr;
+        assembly {
+            addr := mload(add(_bytes, 20))
+        }
+
+        return addr;
     }
 }

--- a/src/forge/ContextConnector.sol
+++ b/src/forge/ContextConnector.sol
@@ -29,7 +29,13 @@ contract ContextConnector {
         if (keyHash == keccak256(abi.encodePacked("confidentialInputs"))) {
             msgContent = confidentialInputs;
         } else if (keyHash == keccak256(abi.encodePacked("kettleAddress"))) {
-            msgContent = abi.encode(kettleAddress);
+            // pad the address to the rigth to 32 bytes
+            bytes20 addr = bytes20(kettleAddress);
+            bytes memory paddedAddress = new bytes(32);
+            for (uint256 i = 0; i < 20; i++) {
+                paddedAddress[i] = addr[i];
+            }
+            msgContent = paddedAddress;
         } else {
             revert("Invalid context key");
         }

--- a/test/protocols/ChatGPT.t.sol
+++ b/test/protocols/ChatGPT.t.sol
@@ -21,6 +21,9 @@ contract ChatGPTTest is Test, SuaveEnabled {
     function getChatGPT() public returns (ChatGPT chatgpt) {
         // NOTE: tried to do it with envOr but it did not worked
         try vm.envString("CHATGPT_API_KEY") returns (string memory apiKey) {
+            if (bytes(apiKey).length == 0) {
+                vm.skip(true);
+            }
             chatgpt = new ChatGPT(apiKey);
         } catch {
             vm.skip(true);


### PR DESCRIPTION
In `suave-geth`, the address is padded with zeros to the **rigth** but in the mock integration is padded to the left.