### PR TITLE
simulateBundle helpers

### DIFF
--- a/src/protocols/Bundle.sol
+++ b/src/protocols/Bundle.sol
@@ -21,7 +21,12 @@ library Bundle {
         return Suave.doHTTPRequest(request);
     }
 
-    function simParams(BundleObj memory args) internal pure returns (bytes memory params) {
+    function simulateBundle(BundleObj memory bundle) internal returns (uint64 egp) {
+        bytes memory simParams = encodeSimParams(bundle);
+        egp = Suave.simulateBundle(simParams);
+    }
+
+    function encodeSimParams(BundleObj memory args) internal pure returns (bytes memory params) {
         params = abi.encodePacked(
             '{"blockNumber": "',
             LibString.toHexString(args.blockNumber),

--- a/test/protocols/Bundle.t.sol
+++ b/test/protocols/Bundle.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import "src/protocols/Bundle.sol";
-import "src/suavelib/Suave.sol";
+import "../../src/protocols/Bundle.sol";
+import "../../src/suavelib/Suave.sol";
 
 contract EthSendBundle is Test {
     function testEthSendBundleEncode() public {
@@ -35,6 +35,27 @@ contract EthSendBundle is Test {
         assertEq(
             string(request3.body),
             '{"jsonrpc":"2.0","method":"eth_sendBundle","params":[{"blockNumber": "0x01", "txs": ["0x1234"], "minTimestamp": 2, "maxTimestamp": 3}],"id":1}'
+        );
+    }
+
+    function testSimBundleParams() public {
+        Bundle.BundleObj memory bundle;
+        bundle.blockNumber = 1;
+        bundle.txns = new bytes[](1);
+        bundle.txns[0] = hex"1234";
+        bundle.refundPercent = 50;
+
+        bytes memory params = Bundle.simParams(bundle);
+        assertEq(string(params), '{"blockNumber": "0x01", "refundPercent": 50, "txs": ["0x1234"]}');
+
+        // encode with 'revertingHashes'
+        bundle.revertingHashes = new bytes32[](1);
+        bundle.revertingHashes[0] = keccak256("hashem");
+
+        bytes memory params2 = Bundle.simParams(bundle);
+        assertEq(
+            string(params2),
+            '{"blockNumber": "0x01", "refundPercent": 50, "revertingHashes": ["0x0a80df9c7574c9524999e774c05a27acf214618b45f4948b88ad1083e13a871a"], "txs": ["0x1234"]}'
         );
     }
 }


### PR DESCRIPTION
- adds `encodeSimParams`: encodes `bundleObj` for `simulateBundle`
- adds `Bundle.simulateBundle(bundleObj)`: syntactical sugar to call `Suave.simulateBundle(encodeSimParams(bundleObj))`

```solidity
bundleObj = Bundle.BundleObj({
    blockNumber: uint64(bundle.blockNumber + i),
    minTimestamp: 0,
    maxTimestamp: 0,
    txns: bundle.txs,
    revertingHashes: new bytes32[](0),
    refundPercent: 51
});

// simulate bundle and revert if it fails
uint64 simResult = Bundle.simulateBundle(bundleObj);
require(simResult > 0, "sim failed");

// send bundle w/ same bundleObj
bundleRes = Bundle.sendBundle(GOERLI_BUNDLE_RPC, bundleObj);
```