### PR TITLE
Do not build contracts when syncing Suave.sol

### DIFF
--- a/.github/workflows/suave-lib-sync.yml
+++ b/.github/workflows/suave-lib-sync.yml
@@ -55,14 +55,8 @@ jobs:
           git add ./src/suavelib/Suave.sol
           rm -rf suave-geth
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
       - name: Regenerate Forge registry
         run: |
-          forge build
           go run ./tools/forge-gen/main.go --apply
           git add ./src/forge/Registry.sol
 


### PR DESCRIPTION
This PR fixes an issue with the automatic Suave.sol lib sync. If a Suave.sol function that was being used gets updated, the `forge build` command will not work and the PR will fail. Thus, we miss those updates.

So, from now on, if there is a failing Suave.sol update, we will amend the PR and fix the usage of the library.