### PR TITLE
Fix suave sync forge not found

### DIFF
--- a/.github/workflows/suave-lib-sync.yml
+++ b/.github/workflows/suave-lib-sync.yml
@@ -55,6 +55,11 @@ jobs:
           git add ./src/suavelib/Suave.sol
           rm -rf suave-geth
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
       - name: Regenerate Forge registry
         run: |
           go run ./tools/forge-gen/main.go --apply


### PR DESCRIPTION
Fixes a bug introduced in #58. The gen tool needs `forge` to lint the contracts.