### PR TITLE
Feature/docs gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cache/
 out/
 src-forge-test/
+docs/

--- a/src/Context.sol
+++ b/src/Context.sol
@@ -3,11 +3,16 @@ pragma solidity ^0.8.13;
 
 import "./suavelib/Suave.sol";
 
+/// @notice Context is a library with functions to retrieve the context of the MEVM execution.
 library Context {
+    /// @notice returns the confidential inputs of the confidential compute request.
+    /// @return output bytes of the confidential inputs.
     function confidentialInputs() internal returns (bytes memory) {
         return Suave.contextGet("confidentialInputs");
     }
 
+    /// @notice returns the address of the Kettle that executes the confidential compute request.
+    /// @return kettleAddress address of the kettle.
     function kettleAddress() internal returns (address) {
         bytes memory _bytes = Suave.contextGet("kettleAddress");
 

--- a/src/Random.sol
+++ b/src/Random.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.8;
 
 import "./suavelib/Suave.sol";
 
+/// @notice Random number generator
 library Random {
     function randomUint8() internal returns (uint8 value) {
         bytes memory random = Suave.randomBytes(1);
@@ -11,6 +12,8 @@ library Random {
         }
     }
 
+    /// @notice Calculate tree age in years, rounded up, for live trees
+    /// @return value is the random number
     function randomUint16() internal returns (uint16 value) {
         bytes memory random = Suave.randomBytes(2);
         assembly {
@@ -18,7 +21,9 @@ library Random {
         }
     }
 
-    function randomUint32() internal returns (uint32 value) {
+    /// @notice Calculate tree age in years, rounded up, for live trees
+    /// @return value is the random number
+    function randomUint32() public returns (uint32 value) {
         bytes memory random = Suave.randomBytes(4);
         assembly {
             value := mload(add(random, 0x04))

--- a/src/Random.sol
+++ b/src/Random.sol
@@ -3,8 +3,10 @@ pragma solidity ^0.8.8;
 
 import "./suavelib/Suave.sol";
 
-/// @notice Random number generator
+/// @notice Random is a library with utilities to generate random data.
 library Random {
+    /// @notice generate a random uint8 number.
+    /// @return value is the random number
     function randomUint8() internal returns (uint8 value) {
         bytes memory random = Suave.randomBytes(1);
         assembly {
@@ -12,7 +14,7 @@ library Random {
         }
     }
 
-    /// @notice Calculate tree age in years, rounded up, for live trees
+    /// @notice generate a random uint16 number.
     /// @return value is the random number
     function randomUint16() internal returns (uint16 value) {
         bytes memory random = Suave.randomBytes(2);
@@ -21,7 +23,7 @@ library Random {
         }
     }
 
-    /// @notice Calculate tree age in years, rounded up, for live trees
+    /// @notice generate a random uint32 number.
     /// @return value is the random number
     function randomUint32() public returns (uint32 value) {
         bytes memory random = Suave.randomBytes(4);
@@ -30,6 +32,8 @@ library Random {
         }
     }
 
+    /// @notice generate a random uint64 number.
+    /// @return value is the random number
     function randomUint64() internal returns (uint64 value) {
         bytes memory random = Suave.randomBytes(8);
         assembly {
@@ -37,6 +41,8 @@ library Random {
         }
     }
 
+    /// @notice generate a random uint128 number.
+    /// @return value is the random number
     function randomUint128() internal returns (uint128 value) {
         bytes memory random = Suave.randomBytes(16);
         assembly {
@@ -44,6 +50,8 @@ library Random {
         }
     }
 
+    /// @notice generate a random uint256 number.
+    /// @return value is the random number
     function randomUint256() internal returns (uint256 value) {
         bytes memory random = Suave.randomBytes(32);
         assembly {

--- a/src/Suapp.sol
+++ b/src/Suapp.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.8;
 
 import "./Logs.sol";
 
+/// @notice Suapp is a contract with general utilities for a Suapp.
 contract Suapp {
+    /// @notice modifier to emit the offchain logs.
     modifier emitOffchainLogs() {
         Logs.decodeLogs(msg.data);
         _;

--- a/src/Transactions.sol
+++ b/src/Transactions.sol
@@ -5,11 +5,23 @@ import "./utils/RLPWriter.sol";
 import "./suavelib/Suave.sol";
 import "Solidity-RLP/RLPReader.sol";
 
+/// @notice Transactions is a library with utilities to encode, decode and sign Ethereum transactions.
 library Transactions {
     using RLPReader for RLPReader.RLPItem;
     using RLPReader for RLPReader.Iterator;
     using RLPReader for bytes;
 
+    /// @notice EIP-155 transaction structure.
+    /// @param to is the target address.
+    /// @param gas is the gas limit.
+    /// @param gasPrice is the gas price.
+    /// @param value is the transfer value in gwei.
+    /// @param nonce is the latest nonce of the sender.
+    /// @param data is the transaction data.
+    /// @param chainId is the id of the chain where the transaction will be executed.
+    /// @param r is the 'r' signature value.
+    /// @param s is the 's' signature value.
+    /// @param v is the 'v' signature value.
     struct EIP155 {
         address to;
         uint256 gas;
@@ -23,6 +35,14 @@ library Transactions {
         uint256 v;
     }
 
+    /// @notice EIP-155 transaction request structure.
+    /// @param to is the target address.
+    /// @param gas is the gas limit.
+    /// @param gasPrice is the gas price.
+    /// @param value is the transfer value in gwei.
+    /// @param nonce is the latest nonce of the sender.
+    /// @param data is the transaction data.
+    /// @param chainId is the id of the chain where the transaction will be executed.
     struct EIP155Request {
         address to;
         uint256 gas;
@@ -33,6 +53,19 @@ library Transactions {
         uint256 chainId;
     }
 
+    /// @notice EIP-1559 transaction structure.
+    /// @param to is the target address.
+    /// @param gas is the gas limit.
+    /// @param maxFeePerGas is the maximum fee per gas.
+    /// @param maxPriorityFeePerGas is the maximum priority fee per gas.
+    /// @param value is the transfer value in gwei.
+    /// @param nonce is the latest nonce of the sender.
+    /// @param data is the transaction data.
+    /// @param chainId is the id of the chain where the transaction will be executed.
+    /// @param accessList is the access list.
+    /// @param r is the 'r' signature value.
+    /// @param s is the 's' signature value.
+    /// @param v is the 'v' signature value.
     struct EIP1559 {
         address to;
         uint256 gas;
@@ -48,6 +81,16 @@ library Transactions {
         uint256 v;
     }
 
+    /// @notice EIP-1559 transaction request structure.
+    /// @param to is the target address.
+    /// @param gas is the gas limit.
+    /// @param maxFeePerGas is the maximum fee per gas.
+    /// @param maxPriorityFeePerGas is the maximum priority fee per gas.
+    /// @param value is the transfer value in gwei.
+    /// @param nonce is the latest nonce of the sender.
+    /// @param data is the transaction data.
+    /// @param chainId is the id of the chain where the transaction will be executed.
+    /// @param accessList is the access list.
     struct EIP1559Request {
         address to;
         uint256 gas;
@@ -60,6 +103,9 @@ library Transactions {
         bytes accessList;
     }
 
+    /// @notice encode a EIP-155 transaction in RLP.
+    /// @param txStruct is the transaction structure.
+    /// @return output the encoded RLP bytes.
     function encodeRLP(EIP155 memory txStruct) internal pure returns (bytes memory) {
         bytes[] memory items = new bytes[](9);
 
@@ -81,6 +127,9 @@ library Transactions {
         return RLPWriter.writeList(items);
     }
 
+    /// @notice encode a EIP-1559 request transaction in RLP.
+    /// @param txStruct is the transaction structure.
+    /// @return output the encoded RLP bytes.
     function encodeRLP(EIP155Request memory txStruct) internal pure returns (bytes memory) {
         bytes[] memory items = new bytes[](9);
 
@@ -102,6 +151,9 @@ library Transactions {
         return RLPWriter.writeList(items);
     }
 
+    /// @notice encode a EIP-1559 transaction in RLP.
+    /// @param txStruct is the transaction structure.
+    /// @return output the encoded RLP bytes.
     function encodeRLP(EIP1559 memory txStruct) internal pure returns (bytes memory) {
         bytes[] memory items = new bytes[](12);
 
@@ -142,6 +194,9 @@ library Transactions {
         return txn;
     }
 
+    /// @notice encode a EIP-1559 request transaction in RLP.
+    /// @param txStruct is the transaction structure.
+    /// @return output the encoded RLP bytes.
     function encodeRLP(EIP1559Request memory txStruct) internal pure returns (bytes memory) {
         bytes[] memory items = new bytes[](9);
 
@@ -178,6 +233,9 @@ library Transactions {
         return txn;
     }
 
+    /// @notice decode a EIP-155 transaction from RLP.
+    /// @param rlp is the encoded RLP bytes.
+    /// @return txStruct the transaction structure.
     function decodeRLP_EIP155(bytes memory rlp) internal pure returns (EIP155 memory) {
         EIP155 memory txStruct;
 
@@ -203,6 +261,9 @@ library Transactions {
         return txStruct;
     }
 
+    /// @notice decode a EIP-155 request transaction from RLP.
+    /// @param rlp is the encoded RLP bytes.
+    /// @return txStruct the transaction structure.
     function decodeRLP_EIP155Request(bytes memory rlp) internal pure returns (EIP155Request memory) {
         EIP155Request memory txStruct;
 
@@ -226,6 +287,9 @@ library Transactions {
         return txStruct;
     }
 
+    /// @notice decode a EIP-1559 transaction from RLP.
+    /// @param rlp is the encoded RLP bytes.
+    /// @return txStruct the transaction structure.
     function decodeRLP_EIP1559(bytes memory rlp) internal pure returns (EIP1559 memory) {
         EIP1559 memory txStruct;
 
@@ -260,6 +324,9 @@ library Transactions {
         return txStruct;
     }
 
+    /// @notice decode a EIP-1559 request transaction from RLP.
+    /// @param rlp is the encoded RLP bytes.
+    /// @return txStruct the transaction structure.
     function decodeRLP_EIP1559Request(bytes memory rlp) internal pure returns (EIP1559Request memory) {
         EIP1559Request memory txStruct;
 
@@ -297,6 +364,10 @@ library Transactions {
         }
     }
 
+    /// @notice sign a EIP-155 transaction request.
+    /// @param request is the transaction request.
+    /// @param signingKey is the private key to sign the transaction.
+    /// @return response the signed transaction.
     function signTxn(Transactions.EIP1559Request memory request, string memory signingKey)
         internal
         returns (Transactions.EIP1559 memory response)
@@ -322,6 +393,10 @@ library Transactions {
         return response;
     }
 
+    /// @notice sign a EIP-155 transaction request.
+    /// @param request is the transaction request.
+    /// @param signingKey is the private key to sign the transaction.
+    /// @return response the signed transaction.
     function signTxn(Transactions.EIP155Request memory request, string memory signingKey)
         internal
         returns (Transactions.EIP155 memory response)

--- a/src/protocols/Bundle.sol
+++ b/src/protocols/Bundle.sol
@@ -6,7 +6,7 @@ import "../utils/HexStrings.sol";
 import "solady/src/utils/LibString.sol";
 import "solady/src/utils/JSONParserLib.sol";
 
-// https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_sendbundle
+/// @notice Bundle is a library with utilities to interact with the Flashbots bundle API described in https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_sendbundle
 library Bundle {
     struct BundleObj {
         uint64 blockNumber;
@@ -18,6 +18,10 @@ library Bundle {
     using JSONParserLib for string;
     using JSONParserLib for JSONParserLib.Item;
 
+    /// @notice send a bundle to the Flashbots relay.
+    /// @param url the URL of the Flashbots relay.
+    /// @param bundle the bundle to send.
+    /// @return response raw bytes response from the Flashbots relay.
     function sendBundle(string memory url, BundleObj memory bundle) internal returns (bytes memory) {
         Suave.HttpRequest memory request = encodeBundle(bundle);
         request.url = url;
@@ -67,6 +71,9 @@ library Bundle {
         return string(result);
     }
 
+    /// @notice decode a bundle from a JSON string.
+    /// @param bundleJson the JSON string of the bundle.
+    /// @return bundle the decoded bundle.
     function decodeBundle(string memory bundleJson) public pure returns (Bundle.BundleObj memory) {
         JSONParserLib.Item memory root = bundleJson.parse();
         JSONParserLib.Item memory txnsNode = root.at('"txs"');

--- a/src/protocols/ChatGPT.sol
+++ b/src/protocols/ChatGPT.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "src/suavelib/Suave.sol";
 import "solady/src/utils/JSONParserLib.sol";
 
+/// @notice ChatGPT is a library with utilities to interact with the OpenAI ChatGPT API.
 contract ChatGPT {
     using JSONParserLib for *;
 
@@ -19,11 +20,15 @@ contract ChatGPT {
         string content;
     }
 
+    /// @notice constructor to create a ChatGPT instance.
+    /// @param _apiKey the API key to interact with the OpenAI ChatGPT.
     constructor(string memory _apiKey) {
         apiKey = _apiKey;
     }
 
-    // https://platform.openai.com/docs/api-reference/making-requests
+    /// @notice complete a chat with the OpenAI ChatGPT.
+    /// @param messages the messages to complete the chat.
+    /// @return message the response from the OpenAI ChatGPT.
     function complete(Message[] memory messages) public returns (string memory) {
         bytes memory body;
         body = abi.encodePacked('{"model": "gpt-3.5-turbo", "messages": [');

--- a/src/protocols/EthJsonRPC.sol
+++ b/src/protocols/EthJsonRPC.sol
@@ -5,6 +5,7 @@ import "src/suavelib/Suave.sol";
 import "solady/src/utils/JSONParserLib.sol";
 import "solady/src/utils/LibString.sol";
 
+/// @notice EthJsonRPC is a library with utilities to interact with an Ethereum JSON-RPC endpoint.
 contract EthJsonRPC {
     using JSONParserLib for *;
 
@@ -14,6 +15,9 @@ contract EthJsonRPC {
         endpoint = _endpoint;
     }
 
+    /// @notice get the nonce of an address.
+    /// @param addr the address to get the nonce.
+    /// @return val the nonce of the address.
     function nonce(address addr) public returns (uint256) {
         bytes memory body = abi.encodePacked(
             '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["',

--- a/src/protocols/MevShare.sol
+++ b/src/protocols/MevShare.sol
@@ -5,7 +5,7 @@ import "../suavelib/Suave.sol";
 import "solady/src/utils/LibString.sol";
 import "solady/src/utils/JSONParserLib.sol";
 
-// https://github.com/flashbots/mev-share/blob/main/specs/bundles/v0.1.md#json-rpc-request-scheme
+/// @notice MevShare is a library with utilities to interact with the Flashbots Mev-Share API described in https://github.com/flashbots/mev-share/blob/main/specs/bundles/v0.1.md#json-rpc-request-scheme
 library MevShare {
     struct Bundle {
         uint64 inclusionBlock;
@@ -71,6 +71,9 @@ library MevShare {
         return request;
     }
 
+    /// @notice send a Mev-Share to the Flashbots Mev-Share API.
+    /// @param url the URL of the Flashbots Mev-Share API.
+    /// @param bundle the Mev-Share bundle to send.
     function sendBundle(string memory url, Bundle memory bundle) internal {
         Suave.HttpRequest memory request = encodeBundle(bundle);
         request.url = url;

--- a/tools/docs-gen/go.mod
+++ b/tools/docs-gen/go.mod
@@ -1,0 +1,10 @@
+module github.com/flashbots/suave-std/tools/docs-gen
+
+go 1.21.0
+
+require github.com/Kunde21/markdownfmt/v3 v3.1.0
+
+require (
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/yuin/goldmark v1.3.5 // indirect
+)

--- a/tools/docs-gen/go.sum
+++ b/tools/docs-gen/go.sum
@@ -1,0 +1,14 @@
+github.com/Kunde21/markdownfmt/v3 v3.1.0 h1:KiZu9LKs+wFFBQKhrZJrFZwtLnCCWJahL+S+E/3VnM0=
+github.com/Kunde21/markdownfmt/v3 v3.1.0/go.mod h1:tPXN1RTyOzJwhfHoon9wUr4HGYmWgVxSQN6VBJDkrVc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/yuin/goldmark v1.3.5 h1:dPmz1Snjq0kmkz159iL7S6WzdahUTHnHB5M56WFVifs=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/docs-gen/main.go
+++ b/tools/docs-gen/main.go
@@ -100,11 +100,12 @@ var docsTemplate = `
 # {{.Name}}
 
 {{.Description}}
+{{$Path := .Path}}
 
 ## Functions
 
 {{range .Functions}}
-### [https://github.com/flashbots/suave-std/#L{{.Pos.FromLine}}]({{.Name}})
+### [{{.Name}}](https://github.com/flashbots/suave-std/tree/main/{{$Path}}#L{{.Pos.FromLine}})
 
 {{.Description}}
 
@@ -128,7 +129,7 @@ Output:
 ## Structs
 
 {{range .Structs}}
-### [https://github.com/flashbots/suave-std/#L{{.Pos.FromLine}}]({{.Name}})
+### [{{.Name}}](https://github.com/flashbots/suave-std/tree/main/{{$Path}}#L{{.Pos.FromLine}})
 
 {{.Description}}
 
@@ -224,6 +225,7 @@ type astNode struct {
 	NodeType      string
 	Nodes         []astNode
 	ContractKind  string
+	Kind          string
 	Documentation *struct {
 		Text string
 	}
@@ -352,8 +354,13 @@ func parseArtifact(artifact *artifact) ([]*ContractDef, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			funcName := astFunc.Name
+			if astFunc.Kind == "constructor" {
+				funcName = "constructor"
+			}
 			funcDecl := FunctionDef{
-				Name:        astFunc.Name,
+				Name:        funcName,
 				Description: natSpec.Description,
 				Pos:         pos,
 				IsModifier:  astFunc.NodeType == modifierDefinitionType,

--- a/tools/docs-gen/main.go
+++ b/tools/docs-gen/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+
+	data, err := os.ReadFile("./out/Random.sol/Random.json")
+	if err != nil {
+		panic(err)
+	}
+
+	// fmt.Println(string(data))
+
+	var artifact artifact
+	if err := json.Unmarshal(data, &artifact); err != nil {
+		panic(err)
+	}
+
+	artifact.Ast.Walk(func(node *astNode) {
+		if node.NodeType != functionDefinitionType {
+			return
+		}
+		if node.Documentation == nil {
+			return
+		}
+
+		funcDef := functionDef{
+			Name:   node.Name,
+			Param:  make(map[string]string),
+			Return: make(map[string]string),
+		}
+
+		lines := strings.Split(node.Documentation.Text, "\n")
+		for _, line := range lines {
+			line = strings.Trim(line, " ")
+			var param string
+
+			if strings.HasPrefix(line, noticePrefix) {
+				line = strings.TrimPrefix(line, noticePrefix)
+				funcDef.Description = line
+
+			} else if strings.HasPrefix(line, paramPrefix) {
+				line = strings.TrimPrefix(line, paramPrefix)
+				param, line = getParamVal(line)
+				funcDef.Param[param] = line
+
+			} else if strings.HasPrefix(line, returnPrefix) {
+				line = strings.TrimPrefix(line, returnPrefix)
+				param, line = getParamVal(line)
+				funcDef.Return[param] = line
+			}
+		}
+
+		fmt.Println("-- funcdef --")
+		fmt.Println(funcDef)
+	})
+}
+
+func getParamVal(line string) (string, string) {
+	indx := strings.Index(line, " ")
+	return line[:indx], line[indx+1:]
+}
+
+type contractDef struct {
+	Path      string
+	Functions []functionDef
+}
+
+var (
+	noticePrefix = "@notice "
+	paramPrefix  = "@param "
+	returnPrefix = "@return "
+)
+
+type functionDef struct {
+	Name        string
+	Description string
+	Param       map[string]string
+	Return      map[string]string
+}
+
+var functionDefinitionType = "FunctionDefinition"
+
+type artifact struct {
+	Ast *astNode `json:"ast"`
+}
+
+type astNode struct {
+	AbsolutePath  string
+	Name          string
+	NodeType      string
+	Nodes         []astNode
+	Documentation *struct {
+		Text string
+	}
+}
+
+func (a *astNode) Walk(handle func(*astNode)) {
+	handle(a)
+	for _, node := range a.Nodes {
+		node.Walk(handle)
+	}
+}

--- a/tools/docs-gen/main_test.go
+++ b/tools/docs-gen/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecodeNatspec(t *testing.T) {
+	cases := []struct {
+		str  string
+		spec *natSpec
+	}{
+
+		{
+			`@notice Calculate tree age in years, rounded up, for live trees
+@return value is the random number`,
+			&natSpec{
+				Description: "Calculate tree age in years, rounded up, for live trees",
+				Param:       []*natValue{},
+				Return: []*natValue{
+					{Name: "value", Description: "is the random number"},
+				},
+			},
+		},
+		{
+			`@notice Calculate tree age in years, rounded up, for live trees
+@param a is the first value
+@param b is the second value
+@return c is the first return value`,
+			&natSpec{
+				Description: "Calculate tree age in years, rounded up, for live trees",
+				Param: []*natValue{
+					{Name: "a", Description: "is the first value"},
+					{Name: "b", Description: "is the second value"},
+				},
+				Return: []*natValue{
+					{Name: "c", Description: "is the fist return value"},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			spec, err := parseNatSpec(c.str)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(spec, c.spec) {
+				t.Fatal("not equal")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR creates a new tool to generate docs for the `suave-std` contracts.

The tool is separated in two steps. First, read the artifacts built by `forge` and create a JSON file with the summary, names, fields, descriptions, etc... for every contract with documentation in the artifacts folder. Second, use a simple template engine to generate the documentation in markdown file from the data generated in the previous step.

The idea to separate in two stages is that eventually we might have the summary generated here but the target for the docs (suave-docs) might decide how to render then.

To generate the docs use:
```
$ cd tools/docs-gen
$ go run main.go --suave-std ../../ --out ../../docs
```

As part of this PR I also added some basic documentation for all the major contracts in `suave-std`.