### PR TITLE
Fix suavelib import path in some protocols

### DIFF
--- a/src/protocols/ChatGPT.sol
+++ b/src/protocols/ChatGPT.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import "src/suavelib/Suave.sol";
+import "../suavelib/Suave.sol";
 import "solady/src/utils/JSONParserLib.sol";
 
 /// @notice ChatGPT is a library with utilities to interact with the OpenAI ChatGPT API.

--- a/src/protocols/EthJsonRPC.sol
+++ b/src/protocols/EthJsonRPC.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-import "src/suavelib/Suave.sol";
+import "../suavelib/Suave.sol";
 import "solady/src/utils/JSONParserLib.sol";
 import "solady/src/utils/LibString.sol";
 


### PR DESCRIPTION
If you use the absolute import path `import "src/suavelib/Suave.sol";` instead of the relative one `import "../suavelib/Suave.sol";` there are errors if you try to import `Suave.sol` again.