### PR TITLE
Fix to allow address(this) in peekers for forge confstore

### DIFF
--- a/src/forge/ConfidentialStore.sol
+++ b/src/forge/ConfidentialStore.sol
@@ -53,9 +53,13 @@ contract ConfidentialStore is Test {
     }
 
     function confidentialStore(Suave.DataId dataId, string memory key, bytes memory value) public {
+        confidentialStore(dataId, key, value, msg.sender);
+    }
+
+    function confidentialStore(Suave.DataId dataId, string memory key, bytes memory value, address sender) public {
         address[] memory allowedStores = dataRecords[dataId].allowedStores;
         for (uint256 i = 0; i < allowedStores.length; i++) {
-            if (allowedStores[i] == msg.sender || allowedStores[i] == Suave.ANYALLOWED) {
+            if (allowedStores[i] == sender || allowedStores[i] == Suave.ANYALLOWED) {
                 dataRecordsContent[dataId][key] = value;
                 return;
             }
@@ -65,9 +69,17 @@ contract ConfidentialStore is Test {
     }
 
     function confidentialRetrieve(Suave.DataId dataId, string memory key) public view returns (bytes memory) {
+        return confidentialRetrieve(dataId, key, msg.sender);
+    }
+
+    function confidentialRetrieve(Suave.DataId dataId, string memory key, address sender)
+        public
+        view
+        returns (bytes memory)
+    {
         address[] memory allowedPeekers = dataRecords[dataId].allowedPeekers;
         for (uint256 i = 0; i < allowedPeekers.length; i++) {
-            if (allowedPeekers[i] == msg.sender || allowedPeekers[i] == Suave.ANYALLOWED) {
+            if (allowedPeekers[i] == sender || allowedPeekers[i] == Suave.ANYALLOWED) {
                 return dataRecordsContent[dataId][key];
             }
         }

--- a/test/Forge.t.sol
+++ b/test/Forge.t.sol
@@ -28,7 +28,18 @@ contract TestForge is Test, SuaveEnabled {
     }
 
     function testForgeConfidentialStoreRecordStore() public {
-        Suave.DataRecord memory record = Suave.newDataRecord(0, addressList, addressList, "namespace");
+        // test with the wildcard
+        _testForgeConfidentialStoreRecordStore(addressList);
+
+        // test with address(this) as the allowed address
+        address[] memory addrList = new address[](1);
+        addrList[0] = address(this);
+
+        _testForgeConfidentialStoreRecordStore(addrList);
+    }
+
+    function _testForgeConfidentialStoreRecordStore(address[] memory addrList) public {
+        Suave.DataRecord memory record = Suave.newDataRecord(0, addrList, addrList, "namespace");
 
         bytes memory value = abi.encode("suave works with forge!");
         Suave.confidentialStore(record.id, "key1", value);


### PR DESCRIPTION
The forge integration of the confidential store uses a "connector" contract to bridge precompile calls from `Suave.sol` to the mock contract. Thus, it was not possible to set `address(this)` as an allowed peeker, because when the mock contract checks, it is the address of the "connector" not the one of the caller contract. This PR fixes that issue.