### PR TITLE
Fix ChatGPT: refactor contract to work in the context of a confidential request

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,16 @@ import "suave-std/protocols/ChatGPT.sol";
 
 contract Example {
     function example() public {
-        ChatGPT chatgpt = new ChatGPT("apikey");
+        //retreive the apiKey
+        bytes memory keyData = Suave.confidentialRetrieve(apiKeyRecord, API_KEY);
+        string memory apiKey = bytesToString(keyData);
+
+        ChatGPT chatgpt = new ChatGPT();
 
         ChatGPT.Message[] memory messages = new ChatGPT.Message[](1);
         messages[0] = ChatGPT.Message(ChatGPT.Role.User, "How do I write a Suapp with suave-std?");
 
-        chatgpt.complete(messages);
+        chatgpt.complete(apiKey, messages);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -160,11 +160,8 @@ import "suave-std/protocols/ChatGPT.sol";
 
 contract Example {
     function example() public {
-        //retreive the apiKey
-        bytes memory keyData = Suave.confidentialRetrieve(apiKeyRecord, API_KEY);
-        string memory apiKey = bytesToString(keyData);
-
         ChatGPT chatgpt = new ChatGPT();
+        string memory apiKey = "xxxx-xx"   // in production, use confidential store
 
         ChatGPT.Message[] memory messages = new ChatGPT.Message[](1);
         messages[0] = ChatGPT.Message(ChatGPT.Role.User, "How do I write a Suapp with suave-std?");

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ import "suave-std/protocols/ChatGPT.sol";
 contract Example {
     function example() public {
         ChatGPT chatgpt = new ChatGPT();
-        string memory apiKey = "xxxx-xx"   // in production, use confidential store
+        string memory apiKey = "xxxx-xx";   // in production, use confidential store
 
         ChatGPT.Message[] memory messages = new ChatGPT.Message[](1);
         messages[0] = ChatGPT.Message(ChatGPT.Role.User, "How do I write a Suapp with suave-std?");

--- a/src/protocols/ChatGPT.sol
+++ b/src/protocols/ChatGPT.sol
@@ -8,8 +8,6 @@ import "solady/src/utils/JSONParserLib.sol";
 contract ChatGPT {
     using JSONParserLib for *;
 
-    string apiKey;
-
     enum Role {
         User,
         System
@@ -20,16 +18,11 @@ contract ChatGPT {
         string content;
     }
 
-    /// @notice constructor to create a ChatGPT instance.
-    /// @param _apiKey the API key to interact with the OpenAI ChatGPT.
-    constructor(string memory _apiKey) {
-        apiKey = _apiKey;
-    }
-
     /// @notice complete a chat with the OpenAI ChatGPT.
+    /// @param apiKey ChatGPT API key
     /// @param messages the messages to complete the chat.
     /// @return message the response from the OpenAI ChatGPT.
-    function complete(Message[] memory messages) public returns (string memory) {
+    function complete(string calldata apiKey, Message[] memory messages) public returns (string memory) {
         bytes memory body;
         body = abi.encodePacked('{"model": "gpt-3.5-turbo", "messages": [');
         for (uint256 i = 0; i < messages.length; i++) {

--- a/test/protocols/ChatGPT.t.sol
+++ b/test/protocols/ChatGPT.t.sol
@@ -7,24 +7,25 @@ import "src/protocols/ChatGPT.sol";
 
 contract ChatGPTTest is Test, SuaveEnabled {
     function testChatGPT() public {
-        ChatGPT chatgpt = getChatGPT();
+        (ChatGPT chatgpt, string memory apiKey) = getChatGPT();
 
         ChatGPT.Message[] memory messages = new ChatGPT.Message[](1);
         messages[0] = ChatGPT.Message(ChatGPT.Role.User, "Say this is a test!");
 
         string memory expected = "This is a test!";
-        string memory found = chatgpt.complete(messages);
+        string memory found = chatgpt.complete(apiKey, messages);
 
         assertEq(found, expected, "ChatGPT did not return the expected result");
     }
 
-    function getChatGPT() public returns (ChatGPT chatgpt) {
+    function getChatGPT() public returns (ChatGPT chatgpt, string memory apiKey) {
         // NOTE: tried to do it with envOr but it did not worked
-        try vm.envString("CHATGPT_API_KEY") returns (string memory apiKey) {
-            if (bytes(apiKey).length == 0) {
+        try vm.envString("CHATGPT_API_KEY") returns (string memory apiKeyEnv) {
+            if (bytes(apiKeyEnv).length == 0) {
                 vm.skip(true);
             }
-            chatgpt = new ChatGPT(apiKey);
+            chatgpt = new ChatGPT();
+            apiKey = apiKeyEnv;
         } catch {
             vm.skip(true);
         }


### PR DESCRIPTION
If my understanding is correct, the current implementation is not working on Rigil testnet when sending a confidential request that uses an instance of ChatGPT, more on this issue here https://github.com/flashbots/suave-geth/issues/243.

This PR refactor `ChatGPT.sol` to not store the `apiKey` in storage and just assume it will be stored confidentially somewhere else and passed as an argument to the `complete()` function.