### PR TITLE
Add balance() to utils/EthJsonRPC.sol

### DIFF
--- a/src/protocols/EthJsonRPC.sol
+++ b/src/protocols/EthJsonRPC.sol
@@ -32,6 +32,21 @@ contract EthJsonRPC {
         return val;
     }
 
+    /// @notice get the balance of an address.
+    /// @param addr the address to get the balance.
+    /// @return val the balance of the address.
+    function balance(address addr) public returns (uint256) {
+        bytes memory body = abi.encodePacked(
+            '{"jsonrpc":"2.0","method":"eth_getBalance","params":["',
+            LibString.toHexStringChecksummed(addr),
+            '","latest"],"id":1}'
+        );
+
+        JSONParserLib.Item memory item = doRequest(string(body));
+        uint256 val = JSONParserLib.parseUintFromHex(trimQuotes(item.value()));
+        return val;
+    }
+
     /// @notice call a contract function.
     /// @param to the address of the contract.
     /// @param data the data of the function.

--- a/test/protocols/EthJsonRPC.t.sol
+++ b/test/protocols/EthJsonRPC.t.sol
@@ -14,6 +14,13 @@ contract EthJsonRPCTest is Test, SuaveEnabled {
         assertEq(nonce, 0);
     }
 
+    function testEthJsonRPCGetBalance() public {
+        EthJsonRPC ethjsonrpc = getEthJsonRPC();
+
+        uint256 balance = ethjsonrpc.balance(address(this));
+        assertEq(balance, 0);
+    }
+
     function testEthJsonRPCCall() public {
         EthJsonRPC ethjsonrpc = getEthJsonRPC();
 


### PR DESCRIPTION
I have implemented a `balance()` function in EthJsonRPC to retrieve the balance of the native token. This function is similar to the nonce() function, which retrieves the nonce. I believe having a function to get the native token balance will be beneficial.

This is my first pull request for this repository. Please let me know if there are any additional tasks I should perform. 