### PR TITLE
Add eth_call with account state overrides for bytecode

### DIFF
--- a/test/protocols/EthJsonRPC.t.sol
+++ b/test/protocols/EthJsonRPC.t.sol
@@ -26,8 +26,27 @@ contract EthJsonRPCTest is Test, SuaveEnabled {
 
         bytes memory data = abi.encodeWithSignature("get_deposit_count()");
         bytes memory result = ethjsonrpc.call(address(0x00000000219ab540356cBB839Cbe05303d7705Fa), data);
+        uint256 resultUint = abi.decode(result, (uint256));
 
-        require(result.length > 0, "result is empty");
+        require(resultUint > 0, "result is empty");
+    }
+
+    function testEthJsonRPCCallWithOverrides() public {
+        EthJsonRPC ethjsonrpc = getEthJsonRPC();
+
+        EthJsonRPC.AccountOverride memory accountOverride = EthJsonRPC.AccountOverride({
+            addr: address(0x00000000219ab540356cBB839Cbe05303d7705Fa),
+            code: type(TestOverrideContract).runtimeCode
+        });
+
+        EthJsonRPC.AccountOverride[] memory acco = new EthJsonRPC.AccountOverride[](1);
+        acco[0] = accountOverride;
+
+        bytes memory data = abi.encodeWithSignature("get_deposit_count()");
+        bytes memory result = ethjsonrpc.call(address(0x00000000219ab540356cBB839Cbe05303d7705Fa), data, acco);
+        uint256 resultUint = abi.decode(result, (uint256));
+
+        require(resultUint == 10, "result is empty");
     }
 
     function getEthJsonRPC() public returns (EthJsonRPC ethjsonrpc) {
@@ -36,5 +55,11 @@ contract EthJsonRPCTest is Test, SuaveEnabled {
         } catch {
             vm.skip(true);
         }
+    }
+}
+
+contract TestOverrideContract {
+    function get_deposit_count() public pure returns (uint256) {
+        return 10;
     }
 }


### PR DESCRIPTION
This PR adds an extra `call()` function to the EthJSONRpc protocol package to include account state overrides for the byte code.