### PR TITLE
Revert on Json RPC error

### DIFF
--- a/src/protocols/EthJsonRPC.sol
+++ b/src/protocols/EthJsonRPC.sol
@@ -119,6 +119,10 @@ contract EthJsonRPC {
         bytes memory output = Suave.doHTTPRequest(request);
 
         JSONParserLib.Item memory item = string(output).parse();
+        JSONParserLib.Item memory err = item.at('"error"');
+        if (!err.isUndefined()) {
+            revert(err.value());
+        }
         return item.at('"result"');
     }
 


### PR DESCRIPTION
There is currently no way to get the error from a JSON RPC call if it fails, which is very annoying for both debugging and contract logic.

This is but a suggestion on how to handle it, alternatives that come up to my mind are:

1. This solution
2. Returning the whole JSON response, not just the `result` item.
3. Adding a `bool success` to the return values, returning `False` and the error as string instead of reverting.