### PR TITLE
add Misc lib w/ stripSelector

### DIFF
--- a/src/utils/Misc.sol
+++ b/src/utils/Misc.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library Misc {
+    /**
+     * @notice Returns the given bytes with the first 4 bytes removed.
+     */
+    function stripSelector(bytes memory data) internal pure returns (bytes memory trimmedData) {
+        trimmedData = new bytes(data.length - 4);
+        assembly {
+            mstore(add(trimmedData, 0x20), sub(mload(add(data, 0x20)), 0x04))
+            mstore(add(trimmedData, 0x20), mload(add(data, 0x24)))
+        }
+    }
+}

--- a/test/utils/Misc.t.sol
+++ b/test/utils/Misc.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "src/Test.sol";
+import "src/utils/Misc.sol";
+
+contract MiscTest is Test {
+    function x(uint256 n) public pure returns (uint256) {
+        return n;
+    }
+
+    function testStripSelector() public pure {
+        bytes memory suaveCalldata = abi.encodeWithSelector(this.x.selector, 123);
+        bytes memory strippedCalldata = Misc.stripSelector(suaveCalldata);
+        assertEq(strippedCalldata.length, 32);
+        uint256 num = abi.decode(strippedCalldata, (uint256));
+        assertEq(num, 123);
+    }
+}


### PR DESCRIPTION
I've found `stripSelector` useful for checking the calldata returned from confidential function calls in forge. Not sure if this is in the right place, but it felt like a common enough problem in this environment.