### PR TITLE
add timeout param to HttpRequest

### DIFF
--- a/src/suavelib/Suave.sol
+++ b/src/suavelib/Suave.sol
@@ -66,6 +66,7 @@ library Suave {
         string[] headers;
         bytes body;
         bool withFlashbotsSignature;
+        uint64 timeout;
     }
 
     /// @notice Result of a simulated transaction.


### PR DESCRIPTION
This should fix the most common cases of this error: `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`.
When not present in the `HttpRequest` struct, suave-geth sets the default to 42ms, instead of interpreting the missing value as 0 and setting the default to 5 seconds, like it should.
Adding the param to the `HttpRequest` struct correctly zeroes the value when it's undefined, so suave-geth can interpret the value correctly.