### PR TITLE
add conf request helper for forge

### DIFF
--- a/src/forge/ConfidentialRequest.sol
+++ b/src/forge/ConfidentialRequest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.8;
+pragma solidity ^0.8.0;
 
 // Send confidential requests in Forge.
 library ConfRequest {

--- a/src/forge/ConfidentialRequest.sol
+++ b/src/forge/ConfidentialRequest.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.8;
+
+// Send confidential requests in Forge.
+library ConfRequest {
+    /// Sends a confidential request; calls offchain function and onchain callback.
+    function sendConfRequest(address to, bytes memory data) internal returns (Status, bytes memory callbackResult) {
+        // offchain execution
+        (bool success, bytes memory suaveCalldata) = to.call(data);
+        if (!success) {
+            return (Status.FAILURE_OFFCHAIN, suaveCalldata);
+        }
+        suaveCalldata = abi.decode(suaveCalldata, (bytes));
+        // onchain callback
+        (success, callbackResult) = to.call(suaveCalldata);
+        if (!success) {
+            return (Status.FAILURE_ONCHAIN, callbackResult);
+        }
+        return (Status.SUCCESS, callbackResult);
+    }
+}
+
+enum Status {
+    SUCCESS,
+    FAILURE_OFFCHAIN,
+    FAILURE_ONCHAIN
+}

--- a/test/forge/ConfidentialRequest.t.sol
+++ b/test/forge/ConfidentialRequest.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../../src/Test.sol";
+import {ConfRequest, Status} from "src/forge/ConfidentialRequest.sol";
+import {NumberSuapp} from "../Forge.t.sol";
+
+contract ConfRequestTest is Test, SuaveEnabled {
+    using ConfRequest for *;
+
+    NumberSuapp numberSuapp = new NumberSuapp();
+
+    function testConfRequest() public {
+        ctx.setConfidentialInputs(abi.encode(0x42));
+        (Status s,) = address(numberSuapp).sendConfRequest(abi.encodeWithSelector(NumberSuapp.setNumber.selector));
+        assertEq(uint256(s), uint256(Status.SUCCESS));
+        assertEq(numberSuapp.number(), 0x42);
+    }
+}

--- a/test/forge/ConfidentialRequest.t.sol
+++ b/test/forge/ConfidentialRequest.t.sol
@@ -7,7 +7,7 @@ import {ConfRequest, Status} from "src/forge/ConfidentialRequest.sol";
 import {NumberSuapp} from "../Forge.t.sol";
 
 contract ConfRequestTest is Test, SuaveEnabled {
-    using ConfRequest for *;
+    using ConfRequest for address;
 
     NumberSuapp numberSuapp = new NumberSuapp();
 


### PR DESCRIPTION
Realized we can easily trigger the callback of a CCR by forwarding its calldata to another `call`. Simplifies testing a lot.

Come to think of it, I wonder if this would be useful in the actual MEVM...