### PR TITLE
Do not use same interface names as Forge to avoid collusions

### DIFF
--- a/src/forge/Connector.sol
+++ b/src/forge/Connector.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 
 import "forge-std/Test.sol";
 
-interface VmSafe {
+interface connectorVmSafeRef {
     struct FfiResult {
         int32 exitCode;
         bytes stdout;
@@ -16,7 +16,7 @@ interface VmSafe {
 }
 
 contract Connector is Test {
-    VmSafe internal constant vmSafe = VmSafe(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    connectorVmSafeRef internal constant vmSafe = connectorVmSafeRef(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function forgeIt(bytes memory addr, bytes memory data) internal returns (bytes memory) {
         string memory root = vmSafe.projectRoot();
@@ -34,7 +34,7 @@ contract Connector is Test {
         inputs[5] = addrHex;
         inputs[6] = dataHex;
 
-        VmSafe.FfiResult memory result = vmSafe.tryFfi(inputs);
+        connectorVmSafeRef.FfiResult memory result = vmSafe.tryFfi(inputs);
         if (result.exitCode == 0) {
             return result.stdout;
         }

--- a/test/Fixtures.sol
+++ b/test/Fixtures.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.13;
 
-interface vmSafe {
+interface fixturesVmSafeRef {
     function readFile(string calldata path) external view returns (string memory data);
 }
 
 library Fixtures {
-    vmSafe constant vm = vmSafe(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    fixturesVmSafeRef constant vm = fixturesVmSafeRef(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function readFixture(string memory path) internal view returns (string memory) {
         string memory fullPath = string.concat("./test/fixtures/", path);


### PR DESCRIPTION
Do not use the same names as `Forge` interfaces, otherwise, there are issues when a project imports both `suave-std` and `Forge`.