### PR TITLE
add ConfKVS

### DIFF
--- a/src/ConfKVS.sol
+++ b/src/ConfKVS.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Suave} from "src/suavelib/Suave.sol";
+
+struct ConfStore {
+    address[] allowedPeekers;
+    address[] allowedStores;
+    string namespace;
+}
+
+struct ConfRecord {
+    Suave.DataId id;
+    string key;
+}
+
+library ConfKVS {
+    /// Create a new data record and store the value. Data is available to consumers immediately.
+    function set(ConfStore memory cs, string memory key, bytes memory value)
+        internal
+        returns (ConfRecord memory confRecord)
+    {
+        Suave.DataRecord memory rec = Suave.newDataRecord(
+            0, cs.allowedPeekers, cs.allowedStores, string(abi.encodePacked(cs.namespace, "::", key))
+        );
+        Suave.confidentialStore(rec.id, key, value);
+        confRecord = ConfRecord(rec.id, key);
+    }
+
+    /// Retrieve the value from the data record.
+    function get(ConfRecord memory confRecord) internal returns (bytes memory) {
+        return Suave.confidentialRetrieve(confRecord.id, confRecord.key);
+    }
+}

--- a/test/ConfKVS.t.sol
+++ b/test/ConfKVS.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "forge-std/Test.sol";
+import "src/forge/ConfidentialStore.sol";
+import {SuaveEnabled} from "src/Test.sol";
+import "forge-std/console2.sol";
+import {ConfStore, ConfRecord, ConfKVS} from "src/ConfKVS.sol";
+
+contract TestConfKVS is Test, SuaveEnabled {
+    using ConfKVS for ConfStore;
+    using ConfKVS for ConfRecord;
+
+    // example initialization of ConfStore; allows any address to peek and store
+    address[] public addressList = [Suave.ANYALLOWED];
+    ConfStore cs = ConfStore(addressList, addressList, "my_app_name");
+
+    /// set a confidential value and retrieve it, make sure the retrieved value matches what we set
+    function testSimpleConfStore() public {
+        string memory secretValue = "hello, suave!";
+        ConfRecord memory cr = cs.set("secretMessage", abi.encodePacked(secretValue));
+
+        bytes memory value = cr.get();
+        assertEq(keccak256(value), keccak256(abi.encodePacked(secretValue)));
+    }
+}


### PR DESCRIPTION
ConfKVS is a distillation of suave's confidential storage primitives designed to radically simplify the process of creating and retrieving confidential storage records.
It always sets decryptionCondition to 0, so that records are always immediately available, because this is the most common usage, and removing a parameter is always nice.

Using it looks like this:

**1. create a ConfStore**

this should generally be stored by your SUAPP contract's constructor

```solidity
ConfStore cs = ConfStore(addressList, addressList, "my_app_name");
```

**2. set var**

(this value also be stored in your SUAPP contract)

```solidity
ConfRecord memory cr = cs.set("secretKey", abi.encodePacked("secret value"));
```

**3. get var**

```solidity
bytes memory secretKey = cr.get();
assert(keccak256(secretKey) == keccak256(abi.encodePacked("secret value")));
```