### PR TITLE
Make decodeSignature internal

### DIFF
--- a/src/Transactions.sol
+++ b/src/Transactions.sol
@@ -427,7 +427,7 @@ library Transactions {
         return response;
     }
 
-    function decodeSignature(bytes memory signature) public pure returns (uint8 v, bytes32 r, bytes32 s) {
+    function decodeSignature(bytes memory signature) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         assembly {
             r := mload(add(signature, 0x20))
             s := mload(add(signature, 0x40))


### PR DESCRIPTION
Using public or external function in a Solidity library forces the library to be externally deployed and linked instead of embedded. From a dev perspective this is super annoying and not that useful.

I don't see a reason why this single function should be public, more so because it is a simple pure function.